### PR TITLE
Additional test case for `straight?`

### DIFF
--- a/src/iloveponies/tests/p_p_p_pokerface.clj
+++ b/src/iloveponies/tests/p_p_p_pokerface.clj
@@ -84,6 +84,7 @@
  low-ace-straight-hand      true
  ["2H" "2D" "3H" "4H" "5H"] false
  ["2H" "3H" "3D" "4H" "6H"] false
+ ["2H" "3H" "4D" "5H" "7H"] false
  high-ace-straight-hand     true)
 
 (facts "straight-flush?" {:exercise 10


### PR DESCRIPTION
The tests for `straight?` pass when the implementation checks for a strictly monotonic sequence:

```clojure
(defn straight? [hand]
  (apply < (sort (map rank hand))))
```

These changes add a test case to not pass such an implementation.